### PR TITLE
Replacing dependency on solidus with dependencies on core, backend and api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ pkg
 spec/dummy
 spec/examples.txt
 .ruby-version
+
+.ruby-gemset
+solidus_virtual_gift_card.iml

--- a/solidus_virtual_gift_card.gemspec
+++ b/solidus_virtual_gift_card.gemspec
@@ -17,9 +17,9 @@ Gem::Specification.new do |s|
   s.require_path = "lib"
   s.requirements << "none"
 
-  s.add_dependency "solidus_core", "~> 1.2.0"
-  s.add_dependency "solidus_api", "~> 1.2.0"
-  s.add_dependency "solidus_backend", "~> 1.2.0"
+  s.add_dependency "solidus_core", "~> 1.4.0"
+  s.add_dependency "solidus_api", "~> 1.4.0"
+  s.add_dependency "solidus_backend", "~> 1.4.0"
   s.add_dependency "deface"
 
   s.add_development_dependency "rspec-rails", "~> 3.2"

--- a/solidus_virtual_gift_card.gemspec
+++ b/solidus_virtual_gift_card.gemspec
@@ -17,9 +17,9 @@ Gem::Specification.new do |s|
   s.require_path = "lib"
   s.requirements << "none"
 
-  s.add_dependency "solidus_core", "~> 1.4.0"
-  s.add_dependency "solidus_api", "~> 1.4.0"
-  s.add_dependency "solidus_backend", "~> 1.4.0"
+  s.add_dependency "solidus_core", [">= 1.2", "< 3"]
+  s.add_dependency "solidus_api", [">= 1.2", "< 3"]
+  s.add_dependency "solidus_backend", [">= 1.2", "< 3"]
   s.add_dependency "deface"
 
   s.add_development_dependency "rspec-rails", "~> 3.2"

--- a/solidus_virtual_gift_card.gemspec
+++ b/solidus_virtual_gift_card.gemspec
@@ -17,9 +17,9 @@ Gem::Specification.new do |s|
   s.require_path = "lib"
   s.requirements << "none"
 
-  s.add_dependency "solidus_core", [">= 1.2", "< 3"]
-  s.add_dependency "solidus_backend", [">= 1.2", "< 3"]
-  s.add_dependency "solidus_api", [">= 1.2", "< 3"]
+  s.add_dependency "solidus_core", "~> 1.2.0"
+  s.add_dependency "solidus_api", "~> 1.2.0"
+  s.add_dependency "solidus_backend", "~> 1.2.0"
   s.add_dependency "deface"
 
   s.add_development_dependency "rspec-rails", "~> 3.2"

--- a/solidus_virtual_gift_card.gemspec
+++ b/solidus_virtual_gift_card.gemspec
@@ -17,7 +17,9 @@ Gem::Specification.new do |s|
   s.require_path = "lib"
   s.requirements << "none"
 
-  s.add_dependency "solidus", "~> 1.2.0"
+  s.add_dependency "solidus_core", [">= 1.2", "< 3"]
+  s.add_dependency "solidus_backend", [">= 1.2", "< 3"]
+  s.add_dependency "solidus_api", [">= 1.2", "< 3"]
   s.add_dependency "deface"
 
   s.add_development_dependency "rspec-rails", "~> 3.2"


### PR DESCRIPTION
The reason: dependency on solidus adds solidus-frontend to the app.

https://github.com/solidusio/solidus_virtual_gift_card/issues/38