### PR TITLE
update solidus dependency and minor version bump

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,13 +5,11 @@ rvm:
   - 2.3.1
 env:
   matrix:
-    - SOLIDUS_BRANCH=v2.4 DB=postgres
     - SOLIDUS_BRANCH=v2.5 DB=postgres
     - SOLIDUS_BRANCH=v2.6 DB=postgres
     - SOLIDUS_BRANCH=v2.7 DB=postgres
     - SOLIDUS_BRANCH=v2.8 DB=postgres
     - SOLIDUS_BRANCH=master DB=postgres
-    - SOLIDUS_BRANCH=v2.4 DB=mysql
     - SOLIDUS_BRANCH=v2.5 DB=mysql
     - SOLIDUS_BRANCH=v2.6 DB=mysql
     - SOLIDUS_BRANCH=v2.7 DB=mysql

--- a/solidus_virtual_gift_card.gemspec
+++ b/solidus_virtual_gift_card.gemspec
@@ -3,9 +3,9 @@
 Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.name        = 'solidus_virtual_gift_card'
-  s.version     = '1.2.0'
+  s.version     = '1.3.0'
   s.summary     = "Virtual gift card for purchase, drops into the user's account as store credit"
-  s.required_ruby_version = ">= 2.2.2"
+  s.required_ruby_version = '>= 2.2.2'
 
   s.author    = 'Solidus Team'
   s.email     = 'contact@solidus.io'
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.requirements << 'none'
 
-  s.add_dependency "solidus", [">= 1.2", "< 3"]
+  s.add_dependency 'solidus', ['>= 2.5', '< 3']
   s.add_dependency 'deface'
 
   s.add_development_dependency 'rspec-rails', '~> 3.2'


### PR DESCRIPTION
As of 2019-05-07, [Solidus versions <= 2.5 are EOL](https://solidus.io/blog/2018/01/04/maintenance-eol-policy.html), and old versions of Solidus have been dropped from CI for this extension. In order to get CI passing for recent versions, there will need to be changes (i.e., related to https://github.com/solidusio/solidus/pull/1943/) that are incompatible with older versions of Solidus.

This also seems like a reasonable time to designate further commits from here moving forward as a new minor version, so I’ve bumped it from `1.2.0` to `1.3.0`.