### PR TITLE
Update Admin View

### DIFF
--- a/app/overrides/admin_user_sidebar_store_credits.rb
+++ b/app/overrides/admin_user_sidebar_store_credits.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 Deface::Override.new(
-  virtual_path: 'spree/admin/users/_sidebar',
+  virtual_path: 'spree/admin/users/_tabs',
   name: 'admin_user_sidebar_store_credits',
   insert_bottom: "[data-hook='admin_user_tab_options']",
-  partial: 'spree/admin/users/gift_card_sidebar'
+  partial: 'spree/admin/users/gift_card_tabs'
 )

--- a/app/views/spree/admin/gift_cards/lookup.html.erb
+++ b/app/views/spree/admin/gift_cards/lookup.html.erb
@@ -1,10 +1,12 @@
-<% content_for :page_title do %>
-  <%= link_to "#{I18n.t('spree.editing_user')} #{@user.email}", edit_admin_user_url(@user) %>
-<% end %>
+<% admin_breadcrumb(link_to plural_resource_name(Spree::LegacyUser), spree.admin_users_path) %>
+<% admin_breadcrumb(link_to @user.email, edit_admin_user_url(@user)) %>
+<% admin_breadcrumb(t('spree.admin.gift_cards.redeem_gift_card')) %>
 
-<%= render :partial => 'spree/admin/users/sidebar', :locals => { :current => :gift_cards } %>
+
+<%= render 'spree/admin/users/sidebar' %>
+<%= render 'spree/admin/users/tabs', current: :gift_cards %>
+
 <% content_for :page_actions do %>
-  <li><%= link_to_with_icon 'arrow-left', Spree.t("admin.store_credits.back_to_user_list"), admin_users_path, class: 'button' %></li>
 <% end %>
 
 <%= form_for :gift_card, url: redeem_admin_user_gift_cards_path do |f| %>

--- a/app/views/spree/admin/users/_gift_card_sidebar.html.erb
+++ b/app/views/spree/admin/users/_gift_card_sidebar.html.erb
@@ -1,3 +1,0 @@
-<li<%== ' class="active"' if current == :gift_cards %>>
-  <%= link_to_with_icon 'gift', Spree.t(:"admin.gift_cards.redeem_gift_card"), spree.lookup_admin_user_gift_cards_path(@user) %>
-</li>

--- a/app/views/spree/admin/users/_gift_card_tabs.html.erb
+++ b/app/views/spree/admin/users/_gift_card_tabs.html.erb
@@ -1,0 +1,3 @@
+<li<%== ' class="active"' if current == :gift_cards %>>
+  <%= link_to t("spree.admin.gift_cards.redeem_gift_card"), spree.lookup_admin_user_gift_cards_path(@user) %>
+</li>


### PR DESCRIPTION
In recent versions of Solidus, the backend has been redesigned, which means that the old overrides and the old breadcrumb conventions need to be updated in order for extensions to use the backend views correctly.

This change updates the Admin / Users view.

Previously, the tabs would not be visible at all, and the breadcrumb would be the old/deprecated style:

<img width="1067" alt="Screen Shot 2019-12-01 at 7 11 10 PM" src="https://user-images.githubusercontent.com/2460418/69927939-d4f4ea00-146e-11ea-82b9-3ed3f2f0d0ed.png">

Both of these issues are now fixed:

<img width="1073" alt="Screen Shot 2019-12-01 at 7 11 29 PM" src="https://user-images.githubusercontent.com/2460418/69927950-de7e5200-146e-11ea-867f-b7fbb8cb16dc.png">
