### PR TITLE
use NumberHelper from ActiveSupport

### DIFF
--- a/app/models/spree/virtual_gift_card.rb
+++ b/app/models/spree/virtual_gift_card.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Spree::VirtualGiftCard < Spree::Base
-  include ActionView::Helpers::NumberHelper
+  include ActiveSupport::NumberHelper
 
   belongs_to :store_credit, class_name: 'Spree::StoreCredit', optional: true
   belongs_to :purchaser, class_name: 'Spree::User', optional: true


### PR DESCRIPTION
I think could be better include `NumberHelper` directly from `ActiveSupport`.

Personally, I found a bit weird use `ActionView` in a model.