### PR TITLE
Fix error on admin order complete

### DIFF
--- a/app/overrides/admin_item_view_gift_card_codes.rb
+++ b/app/overrides/admin_item_view_gift_card_codes.rb
@@ -4,7 +4,7 @@ Deface::Override.new(
   virtual_path: 'spree/admin/orders/confirm/_shipment_manifest',
   name: 'add_gift_cards_to_admin_confirm',
   insert_bottom: '.item-name',
-  partial: 'spree/admin/orders/cart_gift_card_details',
+  partial: 'spree/admin/orders/shipments_gift_card_details',
 )
 
 Deface::Override.new(

--- a/app/views/spree/admin/orders/_cart_gift_card_details.html.erb
+++ b/app/views/spree/admin/orders/_cart_gift_card_details.html.erb
@@ -1,3 +1,0 @@
-<% item.gift_cards.each do |gift_card| %>
-  <%= render partial: "gift_card_details", locals: { gift_card: gift_card } %>
-<% end %>


### PR DESCRIPTION
The partial was attempting to call `gift_cards` on a
shipment manifest instance instead of the line item.

This is correctly done in this partial: https://github.com/solidusio-contrib/solidus_virtual_gift_card/blob/master/app/views/spree/admin/orders/_shipments_gift_card_details.html.erb

This error was first identified here: https://github.com/solidusio-contrib/solidus_virtual_gift_card/issues/70