### PR TITLE
Prevent constant reinitialization

### DIFF
--- a/app/decorators/models/solidus_virtual_gift_card/spree/store_credit_category_decorator.rb
+++ b/app/decorators/models/solidus_virtual_gift_card/spree/store_credit_category_decorator.rb
@@ -3,7 +3,7 @@
 module SolidusVirtualGiftCard
   module Spree
     module StoreCreditCategoryDecorator
-      GIFT_CARD_CATEGORY_NAME = 'Gift Card'
+      GIFT_CARD_CATEGORY_NAME ||= 'Gift Card'
 
       def self.prepended(base)
         base.non_expiring_credit_types |= [GIFT_CARD_CATEGORY_NAME]


### PR DESCRIPTION
This PR is drafted to find a solution to the following warning:
`warning: already initialized constant SolidusVirtualGiftCard::Spree::StoreCreditCategoryDecorator::GIFT_CARD_CATEGORY_NAME`

The commit in the PR is not dealing with the root cause but it does remove the warning.
@the-krg please share the other solution you had in mind.

Also, there seems to be some logic duplication with regards to the 'Gift Card' credit type in the Solidus codebase: https://github.com/solidusio/solidus/blob/master/core/app/models/spree/store_credit_category.rb
This can be perhaps tackled in a separate PR.

 

