### PR TITLE
Upgrade Ruby version

### DIFF
--- a/solidus_virtual_gift_card.gemspec
+++ b/solidus_virtual_gift_card.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.summary     = "Virtual gift card for purchase, drops into the user's account as store credit"
   s.description = s.summary
 
-  s.required_ruby_version = '~> 2.4'
+  s.required_ruby_version = '>= 2.4.0'
 
   s.author   = 'Solidus Team'
   s.email    = 'contact@solidus.io'

--- a/solidus_virtual_gift_card.gemspec
+++ b/solidus_virtual_gift_card.gemspec
@@ -31,6 +31,7 @@ Gem::Specification.new do |s|
   end
 
   s.add_dependency 'deface'
+  s.add_dependency 'coffee-rails'
   s.add_dependency 'solidus_core', ['>= 2.0.0', '< 4']
   s.add_dependency 'solidus_support', '~> 0.5'
 


### PR DESCRIPTION
### What
This PR upgrades the Ruby version to be `>= 2.4` as opposed to just `~> 2.4`. It also adds the `coffee-rails` dependency.