### PR TITLE
Void expired transaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,23 @@ bundle exec rails g solidus_virtual_gift_card:install
 Use Gift Card during Checkout
 -----------------------------
 
-1) Visit /admin/payment_methods and add Gift Card payment method. It shouldn't be available for User and Admin.
-2)
+1) Visit /admin/payment_methods and add the Gift Card payment method. It should not be available to Users or Admins.
+2) During checkout, you can call the API POST /api/orders/:order_id/gift_card_codes(.:format) to add gift card codes to the order.
+3) At the finalization step, the gift cards listed on the order will be used as payment.
+
+Add expire job
+--------------
+
+If you want to change the configuration, you can add the following to an initializer:
+
+SolidusVirtualGiftCard::Config.tap do |config|
+  # Amount of time after which the authorized transaction should be voided
+  config.authorize_timeout = 1.month
+
+  config.schedule_job_class = 'SolidusVirtualGiftCard::VoidExpiredAuthorizedEventsJob'
+end
+
+The last step in the installation process is to configure the SolidusVirtualGiftCard::VoidExpiredAuthorizedEventsJob background job to run regularly. There are different ways to do this depending on the environment your application is running in: Heroku Scheduler, cron etc.
 
 Authorization
 -------------

--- a/app/decorators/models/solidus_virtual_gift_card/spree/order_decorator.rb
+++ b/app/decorators/models/solidus_virtual_gift_card/spree/order_decorator.rb
@@ -39,7 +39,7 @@ module SolidusVirtualGiftCard
       end
 
       def send_gift_card_emails
-        return unless SolidusVirtualGiftCard.configuration.send_gift_card_emails
+        return unless SolidusVirtualGiftCard::Config.send_gift_card_emails
 
         gift_cards.each do |gift_card|
           if gift_card.send_email_at.nil? || gift_card.send_email_at <= DateTime.now

--- a/app/jobs/solidus_virtual_gift_card/void_expired_authorized_events_job.rb
+++ b/app/jobs/solidus_virtual_gift_card/void_expired_authorized_events_job.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module SolidusVirtualGiftCard
+  class VoidExpiredAuthorizedEventsJob < ApplicationJob
+    queue_as :default
+
+    def perform
+      # Subquery to get the latest 'created_at' timestamp for each virtual_gift_card_event_id
+      subquery = ::Spree::VirtualGiftCardEvent
+                 .group(:virtual_gift_card_id)
+                 .select('virtual_gift_card_id, MAX(created_at) AS max_created_at')
+
+      # Main query:
+      # 1. Joins the subquery to get the latest event for each virtual_gift_card_id
+      # 2. Filters events where the 'created_at' is older than the configured 'authorize_timeout'
+      # 3. Filters events where the action is 'authorize', meaning it’s an authorized event
+      ::Spree::VirtualGiftCardEvent
+        .joins("INNER JOIN (#{subquery.to_sql}) AS subquery ON spree_virtual_gift_card_events.virtual_gift_card_id = subquery.virtual_gift_card_id")
+        .where('spree_virtual_gift_card_events.created_at = subquery.max_created_at')
+        .where('spree_virtual_gift_card_events.created_at < ?', Time.current - ::SolidusVirtualGiftCard::Config.authorize_timeout)
+        .where(action: 'authorize').find_each do |event|
+          # Void the event for the associated virtual gift card using its authorization code
+          event.virtual_gift_card.void(event.authorization_code)
+        end
+    end
+  end
+end

--- a/app/models/spree/virtual_gift_card.rb
+++ b/app/models/spree/virtual_gift_card.rb
@@ -279,7 +279,7 @@ class Spree::VirtualGiftCard < Spree::Base
   def create_credit_record(amount, action_attributes = {})
     # Setting credit_to_new_allocation to true will create a new allocation anytime #credit is called
     # If it is not set, it will update the store credit's amount in place
-    credit = if SolidusVirtualGiftCard.configuration.credit_to_new_gift_card
+    credit = if SolidusVirtualGiftCard::Config.credit_to_new_gift_card
                Spree::VirtualGiftCard.new(create_gift_card_record_params(amount))
              else
                self.amount_used = amount_used - amount

--- a/lib/generators/solidus_virtual_gift_card/install/templates/initializer.rb
+++ b/lib/generators/solidus_virtual_gift_card/install/templates/initializer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-SolidusVirtualGiftCard.configure do |config|
+SolidusVirtualGiftCard::Config.tap do |config|
   # Enable or disable sending gift card email notifications
   # Set to `true` to allow emails to be sent, or `false` to disable them
   config.send_gift_card_emails = true

--- a/lib/solidus_virtual_gift_card/configuration.rb
+++ b/lib/solidus_virtual_gift_card/configuration.rb
@@ -1,22 +1,11 @@
 # frozen_string_literal: true
 
+require 'spree/preferences/configuration'
+require 'active_support/all'
+
 module SolidusVirtualGiftCard
-  class Configuration
-    attr_accessor :send_gift_card_emails, :credit_to_new_gift_card
-
-    def initialize(send_gift_card_emails: true, credit_to_new_allocation: false)
-      @send_gift_card_emails = send_gift_card_emails
-      @credit_to_new_allocation = credit_to_new_allocation
-    end
-  end
-
-  class << self
-    def configuration
-      @configuration ||= Configuration.new
-    end
-
-    def configure
-      yield(configuration)
-    end
+  class Configuration < Spree::Preferences::Configuration
+    preference :send_gift_card_emails, :string, default: ''
+    preference :credit_to_new_gift_card, :boolean, default: true
   end
 end

--- a/lib/solidus_virtual_gift_card/configuration.rb
+++ b/lib/solidus_virtual_gift_card/configuration.rb
@@ -7,5 +7,8 @@ module SolidusVirtualGiftCard
   class Configuration < Spree::Preferences::Configuration
     preference :send_gift_card_emails, :string, default: ''
     preference :credit_to_new_gift_card, :boolean, default: true
+
+    preference :authorize_timeout, :time, default: 1.month
+    class_name_attribute :schedule_job_class, default: 'SolidusVirtualGiftCard::VoidExpiredAuthorizedEventsJob'
   end
 end

--- a/lib/solidus_virtual_gift_card/engine.rb
+++ b/lib/solidus_virtual_gift_card/engine.rb
@@ -26,6 +26,10 @@ module SolidusVirtualGiftCard
       paths["app/controllers"] << "lib/solidus_virtual_gift_card/controllers/backend"
     end
 
+    initializer 'solidus_virtual_gift_card.environment', before: :load_config_initializers do
+      SolidusVirtualGiftCard::Config = SolidusVirtualGiftCard::Configuration.new
+    end
+
     initializer "virtual_gift_card.add_static_preference", after: "spree.register.payment_methods" do |app|
       app.config.spree.payment_methods << 'Spree::PaymentMethod::GiftCard'
       app.config.to_prepare do

--- a/lib/solidus_virtual_gift_card/testing_support/factories.rb
+++ b/lib/solidus_virtual_gift_card/testing_support/factories.rb
@@ -31,7 +31,7 @@ FactoryBot.define do
     virtual_gift_card
     amount             { 100.00 }
     authorization_code { "#{virtual_gift_card.id}-GC-20140602164814476128" }
-    action               { Spree::VirtualGiftCard::AUTHORIZE_ACTION }
+    action               { Spree::VirtualGiftCard::ALLOCATION_ACTION }
 
     factory :virtual_gift_card_auth_event, class: 'Spree::VirtualGiftCardEvent' do
       action             { Spree::VirtualGiftCard::AUTHORIZE_ACTION }

--- a/spec/jobs/solidus_virtual_gift_card/void_expired_authorized_events_job_spec.rb
+++ b/spec/jobs/solidus_virtual_gift_card/void_expired_authorized_events_job_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+RSpec.describe SolidusVirtualGiftCard::VoidExpiredAuthorizedEventsJob, type: :job do
+  subject(:call_perform_now) { -> { described_class.perform_now }.call }
+
+  let(:order) { instance_double('Spree::Order', last_for_user?: last_for_user) }
+
+  let(:allocated_gift_card) { create(:redeemable_virtual_gift_card) }
+  let(:authorized_expired_gift_card) { create(:redeemable_virtual_gift_card) }
+  let(:authorized_captured_gift_card) { create(:redeemable_virtual_gift_card) }
+  let(:authorized_gift_card) { create(:redeemable_virtual_gift_card) }
+
+  before do
+    allocated_gift_card
+    allocated_gift_card.events.update_all(created_at: 3.months.ago) # rubocop:disable Rails/SkipsModelValidations
+
+    authorized_expired_gift_card.events.update_all(created_at: 3.months.ago) # rubocop:disable Rails/SkipsModelValidations
+    create(:virtual_gift_card_auth_event, virtual_gift_card: authorized_expired_gift_card, created_at: 2.months.ago)
+
+    authorized_captured_gift_card.events.update_all(created_at: 3.months.ago) # rubocop:disable Rails/SkipsModelValidations
+    create(:virtual_gift_card_auth_event, virtual_gift_card: authorized_captured_gift_card, created_at: 2.months.ago)
+    create(:virtual_gift_card_capture_event, virtual_gift_card: authorized_captured_gift_card, created_at: (2.months - 1.week).ago)
+
+    authorized_gift_card.events.update_all(created_at: 3.months.ago) # rubocop:disable Rails/SkipsModelValidations
+    create(:virtual_gift_card_auth_event, virtual_gift_card: authorized_gift_card, created_at: 25.days.ago)
+  end
+
+  it 'voids the expired transaction' do
+    allow(SolidusVirtualGiftCard::Config).to receive(:authorize_timeout).and_return(1.month)
+
+    expect do
+      call_perform_now
+    end.to change { Spree::VirtualGiftCardEvent.where(action: Spree::VirtualGiftCard::VOID_ACTION).count }.by(1)
+  end
+
+  context 'when the SolidusVirtualGiftCard::Config.authorize_timeout is set to 20 days' do
+    it 'voids the expired transactions' do
+      allow(SolidusVirtualGiftCard::Config).to receive(:authorize_timeout).and_return(20.days)
+
+      expect do
+        call_perform_now
+      end.to change { Spree::VirtualGiftCardEvent.where(action: Spree::VirtualGiftCard::VOID_ACTION).count }.by(2)
+    end
+  end
+end

--- a/spec/models/spree/virtual_gift_card_spec.rb
+++ b/spec/models/spree/virtual_gift_card_spec.rb
@@ -790,7 +790,7 @@ describe Spree::VirtualGiftCard do
       let(:auth_code)       { event_auth_code }
 
       context "when credit_to_new_gift_card is set" do
-        before { allow(SolidusVirtualGiftCard.configuration).to receive(:credit_to_new_gift_card).and_return(true) }
+        before { allow(SolidusVirtualGiftCard::Config).to receive(:credit_to_new_gift_card).and_return(true) }
 
         it "returns true" do
           expect(subject).to be true


### PR DESCRIPTION
Add the ability to void expired authorized transactions.

This PR adds the ability to specify a scheduled job to retrieve all the authorized transactions over a certain amount of time and void them. This ensures that any transactions that were authorized but not captured within the specified timeframe are automatically voided, freeing up the associated gift card amounts for reuse by the user. The job can be configured to run at regular intervals, helping to keep the system clean and prevent unused funds from remaining locked indefinitely